### PR TITLE
change to new C++ interface way

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,30 @@
+# build artifacts
+build/
+obj-x86_64-linux-gnu/
+audiodecoder.*/addon.xml
+
+# commonly used editors
+# vim
+*.swp
+
+# Eclipse
+*.project
+*.cproject
+.classpath
+*.sublime-*
+.settings/
+
+# KDevelop 4
+*.kdev4
+
+# gedit
+*~
+
+# CLion
+/.idea
+
+# clion
+.idea/
+
+# KDev
+*.kdev4

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,15 +7,23 @@ set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
 enable_language(CXX)
 
 find_package(Kodi REQUIRED)
+find_package(p8-platform REQUIRED)
 
-include_directories(${KODI_INCLUDE_DIR}
+include_directories(${KODI_INCLUDE_DIR}/.. # Hack way with "/..", need bigger Kodi cmake rework to match right include ways (becomes done in future)
+                    ${p8-platform_INCLUDE_DIRS}
                     ${PROJECT_SOURCE_DIR}/lib/timidity)
 
 add_subdirectory(lib/timidity)
 
 set(TIMIDITY_SOURCES src/TimidityCodec.cpp)
 
-set(DEPLIBS timidity)
+set(DEPLIBS timidity
+            ${p8-platform_LIBRARIES})
+
+add_definitions(-DLIBRARY_PREFIX="${CMAKE_SHARED_LIBRARY_PREFIX}"
+                -DLIBRARY_SUFFIX="${CMAKE_SHARED_LIBRARY_SUFFIX}")
+
+set(TIMIDITY_ADDITIONAL_BINARY ${PROJECT_BINARY_DIR}/lib/timidity/${CMAKE_SHARED_LIBRARY_PREFIX}timidity${CMAKE_SHARED_LIBRARY_SUFFIX})
 
 build_addon(audiodecoder.timidity TIMIDITY DEPLIBS)
 

--- a/audiodecoder.timidity/addon.xml.in
+++ b/audiodecoder.timidity/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="audiodecoder.timidity"
-  version="1.1.3"
+  version="2.0.0"
   name="Timidity Audio Decoder"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>

--- a/audiodecoder.timidity/resources/settings.xml
+++ b/audiodecoder.timidity/resources/settings.xml
@@ -1,3 +1,16 @@
-<settings>
-  <setting id="soundfont" label="30000" type="file" mask=".sf2|.cfg"/>
+<settings version="1">
+  <section id="addon" label="-1" help="-1">
+    <category id="main" label="128" help="-1">
+      <group id="1" label="-1">
+        <setting id="soundfont" type="path" label="30000" help="-1">
+          <default></default>
+          <constraints>
+            <allowempty>true</allowempty>
+            <masking>.sf2|.cfg</masking>
+          </constraints>
+          <control type="button" format="file"/>
+        </setting>
+      </group>
+    </category>
+  </section>
 </settings>

--- a/lib/timidity/CMakeLists.txt
+++ b/lib/timidity/CMakeLists.txt
@@ -50,4 +50,4 @@ endif(APPLE)
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR} timidity libarc utils)
 
-add_library(timidity STATIC ${SOURCES})
+add_library(timidity ${SOURCES})


### PR DESCRIPTION
Related to xbmc/xbmc#12336

Also becomes the use of timidity changed. There is it now a shared library
who becomes on start copied to another name to allow open with dlopen.
This way allow multiple instances and Kodi no more need itself the hack way.

@notspiff don't shot me :-D

Has tested this way and on Linux it works good, for other OS must it be also checked. But if acceptable for you can be from Kodi itself the way with lib copy removed and be done from addon if needed.

This allow also for audio decoder to use in multiple instance way.