### PR TITLE
[debian] add libp8-platform-dev build dependency

### DIFF
--- a/audiodecoder.timidity/addon.xml.in
+++ b/audiodecoder.timidity/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="audiodecoder.timidity"
-  version="2.0.0"
+  version="2.0.1"
   name="Timidity Audio Decoder"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>

--- a/debian/control
+++ b/debian/control
@@ -1,7 +1,7 @@
 Source: kodi-audiodecoder-timidity
 Priority: extra
 Maintainer: Arne Morten Kvarving <cptspiff@gmail.com>
-Build-Depends: debhelper (>= 8.0.0), cmake, kodi-addon-dev
+Build-Depends: debhelper (>= 8.0.0), cmake, kodi-addon-dev, libp8-platform-dev
 Standards-Version: 3.9.2
 Section: libs
 


### PR DESCRIPTION
usage of p8-platform was introduced at bbea993 (#17)