### PR TITLE
Several changes and fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,7 @@
+cmake_minimum_required(VERSION 3.5)
 project(audiodecoder.timidity)
 
-cmake_minimum_required(VERSION 2.6)
-
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} ${PROJECT_SOURCE_DIR})
-
-enable_language(CXX)
 
 find_package(Kodi REQUIRED)
 find_package(p8-platform REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,11 +14,12 @@ add_subdirectory(lib/timidity)
 
 set(TIMIDITY_SOURCES src/TimidityCodec.cpp)
 
-set(DEPLIBS timidity
-            ${p8-platform_LIBRARIES})
+set(DEPLIBS ${p8-platform_LIBRARIES})
 
 add_definitions(-DLIBRARY_PREFIX="${CMAKE_SHARED_LIBRARY_PREFIX}"
                 -DLIBRARY_SUFFIX="${CMAKE_SHARED_LIBRARY_SUFFIX}")
+
+set(TIMIDITY_ADDITIONAL_BINARY $<TARGET_FILE:timidity>)
 
 if(WIN32)
   add_definitions(-D_CRT_NONSTDC_NO_DEPRECATE)

--- a/README.md
+++ b/README.md
@@ -5,6 +5,10 @@ This is a [Kodi](http://kodi.tv) audio decoder addon for midi files.
 [![Build Status](https://travis-ci.org/xbmc/audiodecoder.timidity.svg?branch=master)](https://travis-ci.org/xbmc/audiodecoder.timidity)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/xbmc/audiodecoder.timidity?svg=true)](https://ci.appveyor.com/project/xbmc/audiodecoder-timidity)
 
+## Requirements
+
+In order to use this addon you have to set a [SoundFont]("https://en.wikipedia.org/wiki/SoundFont") file in Kodi's addon settings.
+
 ## Build instructions
 
 When building the addon you have to use the correct branch depending on which version of Kodi you're building against. 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 version: BuildNr.{build}
 
-image: Visual Studio 2015
+image: Visual Studio 2017
 
 shallow_clone: true
 
@@ -10,14 +10,14 @@ environment:
   app_id: audiodecoder.timidity
 
   matrix:
-    - GENERATOR: "Visual Studio 14"
+    - GENERATOR: "Visual Studio 15"
       CONFIG: Release
-    - GENERATOR: "Visual Studio 14 Win64"
+    - GENERATOR: "Visual Studio 15 Win64"
       CONFIG: Release
-    - GENERATOR: "Visual Studio 14 Win64"
+    - GENERATOR: "Visual Studio 15 Win64"
       CONFIG: Release
       WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.16299.0"
-    - GENERATOR: "Visual Studio 14 ARM"
+    - GENERATOR: "Visual Studio 15 ARM"
       CONFIG: Release
       WINSTORE: -DCMAKE_SYSTEM_NAME=WindowsStore -DCMAKE_SYSTEM_VERSION="10.0.16299.0"
 

--- a/audiodecoder.timidity/addon.xml.in
+++ b/audiodecoder.timidity/addon.xml.in
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <addon
   id="audiodecoder.timidity"
-  version="2.0.1"
+  version="2.0.2"
   name="Timidity Audio Decoder"
   provider-name="spiff">
   <requires>@ADDON_DEPENDS@</requires>

--- a/audiodecoder.timidity/resources/language/English/strings.po
+++ b/audiodecoder.timidity/resources/language/English/strings.po
@@ -15,3 +15,11 @@ msgstr ""
 msgctxt "#30000"
 msgid "Soundfont or config file"
 msgstr ""
+
+msgctxt "#30001"
+msgid "Timidity Audio Decode"
+msgstr ""
+
+msgctxt "#30002"
+msgid "Soundfont not set in settings!"
+msgstr ""

--- a/lib/timidity/CMakeLists.txt
+++ b/lib/timidity/CMakeLists.txt
@@ -40,8 +40,6 @@ set(SOURCES timidity/aq.c
             utils/timer.c
             utils/getopt.c)
  
-add_options(C ALL_BUILDS "-fPIC")
-
 add_definitions(-DHAVE_ALSA_ASOUNDLIB=1 -DHAVE_LIBASOUND=1 -DHAVE_ERRNO_H=1)
 
 if(APPLE)
@@ -56,3 +54,4 @@ endif()
 include_directories(${CMAKE_CURRENT_SOURCE_DIR} timidity libarc utils)
 
 add_library(timidity STATIC ${SOURCES})
+set_property(TARGET timidity PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/lib/timidity/CMakeLists.txt
+++ b/lib/timidity/CMakeLists.txt
@@ -53,5 +53,5 @@ endif()
 
 include_directories(${CMAKE_CURRENT_SOURCE_DIR} timidity libarc utils)
 
-add_library(timidity STATIC ${SOURCES})
+add_library(timidity SHARED ${SOURCES})
 set_property(TARGET timidity PROPERTY POSITION_INDEPENDENT_CODE ON)

--- a/lib/timidity/timidity/aq.c
+++ b/lib/timidity/timidity/aq.c
@@ -53,6 +53,7 @@
 #define MAX_FILLED_TIME 2.0
 
 #if defined(_WIN32)
+#include <windows.h>
 #define usleep(X) Sleep((X) / 1000U)
 #endif
 

--- a/lib/timidity/timidity/common.h
+++ b/lib/timidity/timidity/common.h
@@ -28,6 +28,12 @@
 #include "url.h"
 #include "mblock.h"
 
+#ifdef WIN32
+  #define EXPORT __declspec(dllexport)
+#else
+  #define EXPORT
+#endif
+
 extern char *program_name, current_filename[];
 extern const char *note_name[];
 

--- a/lib/timidity/timidity/playmidi.c
+++ b/lib/timidity/timidity/playmidi.c
@@ -40,7 +40,7 @@
 #include <strings.h>
 #endif
 #include <math.h>
-#ifdef __W32__
+#ifdef WIN32
 #include <windows.h>
 #endif
 #ifdef HAVE_UNISTD_H
@@ -8957,7 +8957,7 @@ static int32 get_rx_drum(struct DrumParts *p, int32 rx)
 static FILE * fp_wav_out;
 #endif
 
-MidiSong *Timidity_LoadSong(char *fn)
+MidiSong EXPORT *Timidity_LoadSong(char *fn)
 {
 	int i, j, rc;
 
@@ -9086,7 +9086,7 @@ MidiSong *Timidity_LoadSong(char *fn)
 }
 
 
-void Timidity_FreeSong(MidiSong *song)
+void EXPORT Timidity_FreeSong(MidiSong *song)
 {
 	// Disconnect the buffer
 	outbuf_set_data( 0 );
@@ -9134,7 +9134,7 @@ void Timidity_FreeSong(MidiSong *song)
 }
 
 
-int Timidity_FillBuffer( MidiSong* song, void *buf, unsigned int size )
+int EXPORT Timidity_FillBuffer( MidiSong* song, void *buf, unsigned int size )
 {
 	if ( song->end_of_song_reached )
 		return 0;
@@ -9202,7 +9202,7 @@ int Timidity_FillBuffer( MidiSong* song, void *buf, unsigned int size )
 }
 
 
-unsigned long Timidity_Seek( MidiSong *song, unsigned long iTimePos )
+unsigned long EXPORT Timidity_Seek( MidiSong *song, unsigned long iTimePos )
 {
 	skip_to( iTimePos/1000*48000);
 	return iTimePos;

--- a/lib/timidity/timidity/sdl_c.c
+++ b/lib/timidity/timidity/sdl_c.c
@@ -96,7 +96,7 @@ ControlMode *interface_d_loader(void)
 }
 
 
-char *Timidity_ErrorMsg()
+const EXPORT char* Timidity_ErrorMsg()
 {
 	return buffer_timidity_error;
 }

--- a/lib/timidity/timidity/timidity.c
+++ b/lib/timidity/timidity/timidity.c
@@ -5408,7 +5408,7 @@ int main(int argc, char **argv)
 extern PlayMode buffer_play_mode; // defined in buffer_a.c
 
 
-int Timidity_Init(int rate, int bits_per_sample, int channels, const char * soundfont_file, const char* cfgfile )
+int EXPORT Timidity_Init(int rate, int bits_per_sample, int channels, const char * soundfont_file, const char* cfgfile )
 {
     int c, err, i;
 
@@ -5515,7 +5515,7 @@ int Timidity_Init(int rate, int bits_per_sample, int channels, const char * soun
 	return 0;
 }
 
-void Timidity_Cleanup()
+void EXPORT Timidity_Cleanup()
 {
 	int i;
 
@@ -5558,7 +5558,7 @@ void Timidity_Cleanup()
 	free_global();
 }
 
-int Timidity_GetLength( MidiSong *song )
+int EXPORT Timidity_GetLength( MidiSong *song )
 {
 	return song->samples / 48000 * 1000;
 }

--- a/src/TimidityCodec.cpp
+++ b/src/TimidityCodec.cpp
@@ -134,7 +134,10 @@ bool CTimidityCodec::Init(const std::string& filename, unsigned int filecache,
                      std::vector<AEChannel>& channellist)
 {
   if (m_soundfont.empty())
+  {
+    kodi::QueueNotification(QUEUE_ERROR, kodi::GetLocalizedString(30001), kodi::GetLocalizedString(30002));
     return false;
+  }
 
   if (!LoadDll(m_usedLibName)) return false;
   if (!REGISTER_DLL_SYMBOL(Timidity_Init)) return false;

--- a/src/TimidityCodec.cpp
+++ b/src/TimidityCodec.cpp
@@ -33,7 +33,7 @@ extern "C" {
 #include "timidity_codec.h"
 }
 
-class CMyAddon : public kodi::addon::CAddonBase
+class ATTRIBUTE_HIDDEN CMyAddon : public kodi::addon::CAddonBase
 {
 public:
   CMyAddon() : m_usedAmount(0) {}
@@ -51,8 +51,8 @@ private:
 
 /*****************************************************************************************************/
 
-class CTimidityCodec : public kodi::addon::CInstanceAudioDecoder,
-                       private CDllHelper
+class ATTRIBUTE_HIDDEN CTimidityCodec : public kodi::addon::CInstanceAudioDecoder,
+                                        private CDllHelper
 {
 public:
   CTimidityCodec(KODI_HANDLE instance, CMyAddon* addon, bool useChild);


### PR DESCRIPTION
The fix is related to https://github.com/xbmc/audiodecoder.timidity/pull/19, timity was mainly designed as own app and not constructed to handle several files together. Shortly before one file is finished, open Kodi the next, in static this brings a crash. With shared a independent memory is created by `dlopen` on next playback. Anyway, the test works fine.

Further was still `dlopen` inside which found nothing :smile: and created addon errors.